### PR TITLE
Ensure project can be built locally

### DIFF
--- a/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
+++ b/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
@@ -16,6 +16,11 @@ android {
         minSdkVersion 16 // Minimum version supported by Cocos2dx
         versionName '1.0.0'
         ndkVersion = "16.1.4479499"
+
+        // build config doesn't automatically include these values anymore but they're used
+        // by the cocos2dx plugin - add them manually
+        buildConfigField 'int', 'VERSION_CODE', "1"
+        buildConfigField 'String', 'VERSION_NAME', "\"1.0.0\""
     }
 }
 

--- a/src/cocoa/BugsnagCocos2dx.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/src/cocoa/BugsnagCocos2dx.xcodeproj/project.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+	<key>PreviewsEnabled</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
## Goal

Ensures that the project can be built locally with the latest tools. This alters the following:

- bumps bugsnag-android from v4.22.2 to v4.22.3 to include ANR detection polling fix
- sets bugsnag-android example app to explicit version of v4.22.3 to prevent compilation failures
- enforced the use of the legacy build system when building the cocoa notifier

Additionally, it was necessary to define `ANDROID_NDK_HOME` to point at the NDK installation directory.

I have confirmed that this gets things compiling but haven't yet tested out the package in an example app (this is next on the agenda)