### PR TITLE
Backport persistenceDirectory config option

### DIFF
--- a/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
+++ b/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
@@ -16,6 +16,11 @@ android {
         minSdkVersion 16 // Minimum version supported by Cocos2dx
         versionName '1.0.0'
         ndkVersion = "16.1.4479499"
+
+        // build config doesn't automatically include these values anymore but they're used
+        // by the cocos2dx plugin - add them manually
+        buildConfigField 'int', 'VERSION_CODE', "1"
+        buildConfigField 'String', 'VERSION_NAME', "\"1.0.0\""
     }
 }
 


### PR DESCRIPTION
## Goal

Updates the SDK to support the `persistenceDirectory` config option on Android, as added in here: https://github.com/bugsnag/bugsnag-android/pull/1532

## Testing

Manually verified in the Android example app that the error/session files can be stored in the `filesDir` instead of the default `cacheDir`.