### PR TITLE
[Android] fix building the library with default settings

### DIFF
--- a/examples/example-cpp-app/bugsnag/android/bugsnag-plugin-android-cocos2dx/build.gradle
+++ b/examples/example-cpp-app/bugsnag/android/bugsnag-plugin-android-cocos2dx/build.gradle
@@ -14,7 +14,6 @@ android {
 
     defaultConfig {
         minSdkVersion 16 // Minimum version supported by Cocos2dx
-        ndkVersion = "16.1.4479499"
 
         // manually specify removed BuildConfig.VERSION_NAME field
         // https://developer.android.com/studio/releases/gradle-plugin#version_properties_removed_from_buildconfig_class_in_library_projects

--- a/examples/example-cpp-app/cocos2d/cocos/platform/android/libcocos2dx/build.gradle
+++ b/examples/example-cpp-app/cocos2d/cocos/platform/android/libcocos2dx/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion PROP_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
-        ndkVersion = "16.1.4479499"
     }
 
     sourceSets.main {

--- a/examples/example-cpp-app/proj.android/app/build.gradle
+++ b/examples/example-cpp-app/proj.android/app/build.gradle
@@ -12,7 +12,6 @@ android {
         targetSdkVersion PROP_TARGET_SDK_VERSION
         versionCode 1
         versionName "1.0"
-        ndkVersion = "16.1.4479499"
 
         externalNativeBuild {
             if (PROP_BUILD_TYPE == 'ndk-build') {

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -10,6 +10,7 @@ if (( $# != 1 )); then
 fi
 RELEASE_VERSION="$1"
 echo Bumping the version number to $RELEASE_VERSION
-sed -i '' "s/versionName \'.*\'/versionName \'$RELEASE_VERSION\'/" src/android/bugsnag-plugin-android-cocos2dx/build.gradle
-sed -i '' "s/BUGSNAG_COCOS2DX_VERSION =.*/BUGSNAG_COCOS2DX_VERSION = @\"$RELEASE_VERSION\";/" src/cocoa/BugsnagCocos2dxPlugin.m
-sed -i '' "s/## TBD/## $RELEASE_VERSION ($(date '+%Y-%m-%d'))/" CHANGELOG.md
+sed -i'' "s/versionName '.*'/versionName '$RELEASE_VERSION'/" src/android/bugsnag-plugin-android-cocos2dx/build.gradle
+sed -i'' "s/pluginVersion = \".*\"/pluginVersion = \"$RELEASE_VERSION\"/" src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
+sed -i'' "s/BUGSNAG_COCOS2DX_VERSION =.*/BUGSNAG_COCOS2DX_VERSION = @\"$RELEASE_VERSION\";/" src/cocoa/BugsnagCocos2dxPlugin.m
+sed -i'' "s/## TBD/## $RELEASE_VERSION ($(date '+%Y-%m-%d'))/" CHANGELOG.md

--- a/scripts/export-package.sh
+++ b/scripts/export-package.sh
@@ -50,10 +50,11 @@ install "$PROJ_DIR"/src/CMakeLists.txt "$PROJ_DIR"/build/pkg/
 echo "Assembling android artifacts..."
 mkdir -p "$PROJ_DIR"/build/android
 pushd src/android/bugsnag-android
-    ./gradlew --quiet bugsnag-android-core:assembleRelease
-    ./gradlew --quiet bugsnag-plugin-android-ndk:assembleRelease
-    ./gradlew --quiet bugsnag-plugin-android-anr:assembleRelease
-    ./gradlew --quiet bugsnag-android:assembleRelease
+GRADLE="./gradlew --quiet -PABI_FILTERS=x86,x86_64,armeabi-v7a,arm64-v8a"
+    $GRADLE bugsnag-android-core:assembleRelease
+    $GRADLE bugsnag-plugin-android-ndk:assembleRelease
+    $GRADLE bugsnag-plugin-android-anr:assembleRelease
+    $GRADLE bugsnag-android:assembleRelease
 popd
 
 ANDROID_ARTIFACTS=$(ls "$PROJ_DIR"/src/android/bugsnag-android/bugsnag-*/build/outputs/aar/bugsnag-{android,android-core,plugin-*}-release.aar)

--- a/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
+++ b/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
@@ -15,12 +15,6 @@ android {
     defaultConfig {
         minSdkVersion 16 // Minimum version supported by Cocos2dx
         versionName '1.0.0'
-        ndkVersion = "16.1.4479499"
-
-        // build config doesn't automatically include these values anymore but they're used
-        // by the cocos2dx plugin - add them manually
-        buildConfigField 'int', 'VERSION_CODE', "1"
-        buildConfigField 'String', 'VERSION_NAME', "\"1.0.0\""
     }
 }
 

--- a/src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
+++ b/src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
@@ -3,12 +3,13 @@ package com.bugsnag.android;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.bugsnag.android.cocos2dx.BuildConfig;
-
 public class BugsnagCocos2dxPlugin implements BugsnagPlugin {
 
     /** Formatted, cached copy of the cocos2d version */
     private static String version = null;
+
+    /** Release version of the bugsnag cocos2d-x plugin */
+    private static String pluginVersion = "1.0.0";
 
     private boolean loaded = false;
 
@@ -61,13 +62,13 @@ public class BugsnagCocos2dxPlugin implements BugsnagPlugin {
             }
         });
 
-        Logger.info("Initialized Cocos2d-x plugin " + BuildConfig.VERSION_NAME);
+        Logger.info("Initialized Cocos2d-x plugin " + pluginVersion);
     }
 
     private void configureNotifierDetails() {
         Notifier notifier = Notifier.getInstance();
         notifier.setName("Bugsnag Cocos2d-x");
-        notifier.setVersion(BuildConfig.VERSION_NAME);
+        notifier.setVersion(pluginVersion);
         notifier.setURL("https://github.com/bugsnag/bugsnag-cocos2dx");
     }
 


### PR DESCRIPTION
## Goal

Given a vanilla cocos2d project, its likely using an older version of gradle without support for specifying `ndkVersion`, and adding `buildConfigField` breaks the build by introducing duplicate fields for `VERSION_NAME` and `VERSION_CODE`.

Specifying `ndkVersion` in example projects prevents the app from building unnecessarily when a different NDK revision is installed.

Also added a small improvement to the export script to specify ABIs, as the current bugsnag-android library version included now-unsupported ones.

## Questions

* Can we specify the `buildConfigField`s conditionally if needed? Otherwise it seems safe to assume either A) no one is upgrading their gradle versions in isolation or B) they've changed the cocos internals enough to be able to figure out what to do.

## Testing

* Tested manually to ensure a new project could compile successfully