### PR TITLE
fix(android): ensure JNI functions are exported

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,10 +4,17 @@ if(ANDROID OR APPLE) # Supports Android, iOS, and macOS
 
 set(BUGSNAG_LIB bugsnag-cocos2dx)
 project(${BUGSNAG_LIB})
+set(EXTRA_LINKING_FLAGS "")
 
 if(ANDROID)
     add_library(${BUGSNAG_LIB} STATIC android/Bugsnag.cpp)
-    target_include_directories(${BUGSNAG_LIB} 
+    set(EXTRA_LINKING_FLAGS
+        # Ensure JNI functions are exported from the host shared library, in
+        # case the host is configured to hide all symbols through linker options
+        -uJava_com_bugsnag_android_BugsnagCocos2dxPlugin_getCocos2dVersion
+        -uJava_com_bugsnag_android_BugsnagCocos2dxPlugin_configureNativeComponents)
+
+    target_include_directories(${BUGSNAG_LIB}
         PUBLIC include
         PRIVATE android/private)
     target_link_libraries(${BUGSNAG_LIB} cocos2d)
@@ -35,4 +42,6 @@ endif()
 set_target_properties(${BUGSNAG_LIB} PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_SOURCE_DIR}/bugsnag/include)
 
+# Export settings into parent project
+set(BUGSNAG_LINKER_FLAGS ${EXTRA_LINKING_FLAGS} PARENT_SCOPE)
 endif()


### PR DESCRIPTION
## Goal

Without this specified, and the host project including `${BUGSNAG_LINKER_OPTIONS}` (upcoming docs PR) when linking against the bugsnag library, its possible that the symbols won't be visible in the symbol table and
unable to be called from Java.

If the default CMake version was at least 3.13, we could instead specify [`target_link_options()`](https://cmake.org/cmake/help/v3.22/command/target_link_options.html) without requiring use of an extra variable.

## Changeset

* Export linking flags for use with `target_link_library`. The updated installation will look like:

```cmake
if(ANDROID OR APPLE)
    add_subdirectory(bugsnag)
    target_link_libraries(${APP_NAME} bugsnag-cocos2dx ${BUGSNAG_LINKER_FLAGS})
endif()
```

## Testing

* Tested manually that events and sessions could be sent from Android devices in a new Cocos2d-x 4.0 project.