### PR TITLE
Prepare for v1.1.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,10 @@
 
 ### Bug fixes
 
-* (Android) Bump the bugsnag-android dependency version to v4.22.3
 * (Android) Fix UTF-8 encoding errors in Bugsnag::notify [bugsnag-android#1542](https://github.com/bugsnag/bugsnag-android/pull/1542)
+* Update bugsnag-android to v4.22.3
+  * Allow disabling previous signal handler invocation for Unity ANRs [bugsnag-android#743]
+  * Avoid polling when detecting ANRs by invoking JNI from SIGQUIT handler [bugsnag-android#741]
 
 ## 1.0.0 (2020-01-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
 # Changelog
 
-## TBD
+## 1.1.0 (2021-12-06)
 
 ### Enhancements
 
 * Backport `persistenceDirectory` config option to Android [bugsnag-cocos2dx#6](https://github.com/bugsnag/bugsnag-cocos2dx/pull/6)
+
+### Bug fixes
+
+* (Android) Bump the bugsnag-android dependency version to v4.22.3
+* (Android) Fix UTF-8 encoding errors in Bugsnag::notify [bugsnag-android#1542](https://github.com/bugsnag/bugsnag-android/pull/1542)
 
 ## 1.0.0 (2020-01-07)
 


### PR DESCRIPTION
## Goal

Prepares the SDK for v1.1.0 release by updating to use the latest `cocos2dx-main` branch and altering the release date.