### PR TITLE
Use macOS 12 build servers

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,5 @@
 agents:
-  queue: opensource-mac-cocoa-10.15
+  queue: opensource-arm-mac-cocoa-12
 
 steps:
   - name: 'Run macOS unit tests'


### PR DESCRIPTION
## Goal

Bump the Buildkite pipeline steps to use macOS 12 (ARM) servers.

## Testing

Covered by CI.