### PR TITLE
Update bugsnag-cocos2d API to better match the standard API

### DIFF
--- a/src/Bugsnag.hpp
+++ b/src/Bugsnag.hpp
@@ -114,13 +114,21 @@ public:
    * @see startSession
    * @see pauseSession
    */
-  static void resumeSession();
+  static bool resumeSession();
 
   /**
    * Leave a "breadcrumb" log message with additional information about the
    * environment at the time the breadcrumb was captured.
    */
-  static void leaveBreadcrumb(string name, BreadcrumbType type,
+  static void leaveBreadcrumb(string message, map<string, string> metadata,
+                              BreadcrumbType type);
+
+  /**
+   * Leave a "breadcrumb" log message with additional information about the
+   * environment at the time the breadcrumb was captured.
+   * DEPRECATED API
+   */
+  static void leaveBreadcrumb(string message, BreadcrumbType type,
                               map<string, string> metadata);
 
   /**
@@ -128,6 +136,12 @@ public:
    *  delete the current value for key
    */
   static void addMetadata(string section, string key, string value);
+
+  /**
+   * Add custom data to send to Bugsnag with every exception under the specified
+   * section.
+   */
+  static void addMetadata(string section, map<string, string> metadata);
 
   /** Remove custom data from Bugsnag reports. */
   static void clearMetadata(string section);

--- a/src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
+++ b/src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
@@ -1,6 +1,6 @@
 package com.bugsnag.android;
 
-import java.util.Arrays;
+import java.util.Collections;
 
 public class BugsnagCocos2dxPlugin implements Plugin {
     static final String pluginVersion = "1.1.0";

--- a/src/cocoa/Bugsnag.mm
+++ b/src/cocoa/Bugsnag.mm
@@ -48,11 +48,15 @@ void Bugsnag::pauseSession() {
     [NSClassFromString(@"Bugsnag") pauseSession];
 }
 
-void Bugsnag::resumeSession() {
-    [NSClassFromString(@"Bugsnag") resumeSession];
+bool Bugsnag::resumeSession() {
+    return [NSClassFromString(@"Bugsnag") resumeSession];
 }
 
 void Bugsnag::leaveBreadcrumb(string name, BreadcrumbType type, map<string, string> metadata) {
+    return Bugsnag::leaveBreadcrumb(name, metadata, type);
+}
+
+void Bugsnag::leaveBreadcrumb(string name, map<string, string> metadata, BreadcrumbType type) {
     NSMutableDictionary *ns_metadata = [NSMutableDictionary new];
     BSGBreadcrumbType ns_type = _getBreadcrumbType(type);
     NSString *ns_name = [NSString stringWithCString:name.c_str() encoding:NSUTF8StringEncoding];
@@ -70,6 +74,17 @@ void Bugsnag::addMetadata(string section, string key, string value) {
     NSString *ns_key = [NSString stringWithCString:key.c_str() encoding:NSUTF8StringEncoding];
     NSString *ns_value = [NSString stringWithCString:value.c_str() encoding:NSUTF8StringEncoding];
     [NSClassFromString(@"Bugsnag") addMetadata:ns_value withKey:ns_key toSection:ns_section];
+}
+
+void Bugsnag::addMetadata(string section, map<string, string> metadata) {
+    NSString *ns_section = [NSString stringWithCString:section.c_str() encoding:NSUTF8StringEncoding];
+    NSMutableDictionary *ns_metadata = [NSMutableDictionary new];
+    for (pair<string, string> item : metadata) {
+        NSString *key = [NSString stringWithCString:item.first.c_str() encoding:NSUTF8StringEncoding];
+        NSString *obj = [NSString stringWithCString:item.second.c_str() encoding:NSUTF8StringEncoding];
+        [ns_metadata setObject:obj forKey:key];
+    }
+    [NSClassFromString(@"Bugsnag") addMetadata:ns_metadata toSection:ns_section];
 }
 
 void Bugsnag::clearMetadata(string section, string key) {


### PR DESCRIPTION
## Goal

Update cocos2d-x API to more closely match the cross-platform spec, following the plan in ROAD-1056:

* bool resumeSession() **(changed return type)**
* void addMetadata(string section, map<string, string> metadata) **(new method)**
* void leaveBreadcrumb(string message, map<string, string> metadata, BreadcrumbType type) **(new overload with changed argument order)**

## Testing

Manually tested in ios and android apps running cocos2d 3.x and 4.x.