### PR TITLE
Bump version to 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.1 (TBD)
+## 2.0.1 (2022-04-06)
 
 ### Enhancements
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -12,5 +12,5 @@ RELEASE_VERSION="$1"
 echo Bumping the version number to $RELEASE_VERSION
 sed -i '' "s/versionName '.*'/versionName '$RELEASE_VERSION'/" src/android/bugsnag-plugin-android-cocos2dx/build.gradle
 sed -i '' "s/pluginVersion = \".*\"/pluginVersion = \"$RELEASE_VERSION\"/" src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
-sed -i '' "s/BUGSNAG_COCOS2DX_VERSION =.*/BUGSNAG_COCOS2DX_VERSION = @\"$RELEASE_VERSION\";/" src/cocoa/BugsnagCocos2dxPlugin.m
+sed -i '' "s/BUGSNAG_COCOS2DX_VERSION =.*/BUGSNAG_COCOS2DX_VERSION = @\"$RELEASE_VERSION\";/" src/cocoa/BugsnagCocos2dxPlugin.mm
 sed -i '' "s/## TBD/## $RELEASE_VERSION ($(date '+%Y-%m-%d'))/" CHANGELOG.md

--- a/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
+++ b/src/android/bugsnag-plugin-android-cocos2dx/build.gradle
@@ -14,7 +14,7 @@ android {
 
     defaultConfig {
         minSdkVersion 16 // Minimum version supported by Cocos2dx
-        versionName '1.1.0'
+        versionName '2.0.1'
     }
 }
 

--- a/src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
+++ b/src/android/bugsnag-plugin-android-cocos2dx/src/main/java/com/bugsnag/android/BugsnagCocos2dxPlugin.java
@@ -3,7 +3,7 @@ package com.bugsnag.android;
 import java.util.Collections;
 
 public class BugsnagCocos2dxPlugin implements Plugin {
-    static final String pluginVersion = "1.1.0";
+    static final String pluginVersion = "2.0.1";
 
     @Override
     public void unload() {

--- a/src/cocoa/BugsnagCocos2dxPlugin.mm
+++ b/src/cocoa/BugsnagCocos2dxPlugin.mm
@@ -2,7 +2,7 @@
 #import "BugsnagClient+Private.h"
 #import "BugsnagNotifier.h"
 
-static NSString *const BUGSNAG_COCOS2DX_VERSION = @"1.1.0";
+static NSString *const BUGSNAG_COCOS2DX_VERSION = @"2.0.1";
 
 namespace cocos2d {
     extern const char* cocos2dVersion();


### PR DESCRIPTION
Changes from 2.0.0 to 2.0.1:

### Enhancements

* Updates the bugsnag-android dependency from v5.19.1 to [v5.22.0](https://github.com/bugsnag/bugsnag-android/blob/master/CHANGELOG.md#5220-2022-03-31)
* Updates the bugsnag-cocoa dependency from v6.16.1 to [v6.16.5](https://github.com/bugsnag/bugsnag-cocoa/blob/master/CHANGELOG.md#6165-2022-03-30)


## Testing

Manual testing with the example app